### PR TITLE
feat: allow transformation of field values in rich text nodes.

### DIFF
--- a/packages/gatsby-source-contentful/src/__tests__/normalize.js
+++ b/packages/gatsby-source-contentful/src/__tests__/normalize.js
@@ -298,4 +298,47 @@ describe(`rich-text entry field inclusion/exclusion`, () => {
       expect(includedFields).toContain(`body`)
     })
   })
+
+  describe(`when there is an entryFieldTransformer`, () => {
+    const pluginOptions = {
+      richText: {
+        entryFieldTransformer: fields => {
+          if (fields.slug) {
+            delete fields.slug
+          }
+
+          return fields
+        },
+      },
+    }
+
+    it(`transforms the field values using the entryFieldTransformer`, () => {
+      const entryItemFieldValue = {
+        data: {
+          target: {
+            sys: { id: `id123` },
+            fields: {
+              title: `This is a title`,
+              body: `This is the body`,
+              slug: `this-is-a-slug`,
+            },
+          },
+        },
+      }
+      const resolvable = new Set()
+      resolvable.add(`id123`)
+
+      normalize.applyRichTextEntryFieldFilters(
+        entryItemFieldValue,
+        resolvable,
+        pluginOptions
+      )
+
+      const transformedFields = Object.keys(
+        entryItemFieldValue.data.target.fields
+      )
+
+      expect(transformedFields).not.toContain(`slug`)
+    })
+  })
 })

--- a/packages/gatsby-source-contentful/src/normalize.js
+++ b/packages/gatsby-source-contentful/src/normalize.js
@@ -242,13 +242,18 @@ function applyRichTextEntryFieldFilters(
     _.get(entryItemFieldValue, `data.target.sys.id`) &&
     resolvable.has(entryItemFieldValue.data.target.sys.id)
   ) {
-    const { includeEntryFields, excludeEntryFields } = options.richText || {}
+    const { entryFieldTransformer, includeEntryFields, excludeEntryFields } =
+      options.richText || {}
 
     let fields = entryItemFieldValue.data.target.fields
     if (includeEntryFields) {
       fields = _.pick(fields, includeEntryFields)
     } else if (excludeEntryFields) {
       fields = _.omit(fields, excludeEntryFields)
+    }
+
+    if (entryFieldTransformer) {
+      fields = entryFieldTransformer(fields)
     }
 
     entryItemFieldValue.data.target = {


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description
This extends on the previous work done by including a new plugin option, `entryFieldTransformer`. This new option accepts a `field` argument, transforms it in any way the user wants it, and then returns the transformed `field` value.

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues
Fixes [#11364](https://github.com/gatsbyjs/gatsby/issues/11364)
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
