### PR TITLE
chore: add entryFieldTransfomer to plugin-option

### DIFF
--- a/packages/gatsby-source-contentful/README.md
+++ b/packages/gatsby-source-contentful/README.md
@@ -156,6 +156,10 @@ List of locales and their codes can be found in Contentful app -> Settings -> Lo
 
 If you have entries that reference each other via their rich-text fields, Gatsby may get stuck in an infinite loop during build and throw a `Maximum call stack size exceeded` error. To prevent this, you can filter which fields should be included in entries referenced by the field. Set a list of field names to include or exclude using this option, and Gatsby will filter the fields of referenced entries accordingly.
 
+**`entryFieldTransformer`** [function][optional] [default: `undefined`]
+
+This allows for the transformation of rich-text fields in any way. It allows you to pass in a rich-text field into a function and then modify/add/delete inner field values.
+
 ## Notes on Contentful Content Models
 
 There are currently some things to keep in mind when building your content models at Contentful.

--- a/packages/gatsby-source-contentful/src/__tests__/plugin-options.js
+++ b/packages/gatsby-source-contentful/src/__tests__/plugin-options.js
@@ -159,6 +159,25 @@ describe(`Options validation`, () => {
     expect(reporter.panic).toBeCalled()
   })
 
+  it(`Passes with a richText.entryFieldTransformer option`, () => {
+    validateOptions(
+      {
+        reporter,
+      },
+      {
+        spaceId: `spaceId`,
+        accessToken: `accessToken`,
+        localeFilter: locale => locale.code === `de`,
+        downloadLocal: false,
+        richText: {
+          entryFieldTransformer: () => {},
+        },
+      }
+    )
+
+    expect(reporter.panic).not.toBeCalled()
+  })
+
   it(`Fails with missing required options`, () => {
     validateOptions(
       {

--- a/packages/gatsby-source-contentful/src/plugin-options.js
+++ b/packages/gatsby-source-contentful/src/plugin-options.js
@@ -36,8 +36,9 @@ const optionsSchema = Joi.object().keys({
     .keys({
       includeEntryFields: Joi.array().items(Joi.string()),
       excludeEntryFields: Joi.array().items(Joi.string()),
+      entryFieldTransformer: Joi.func(),
     })
-    .oxor(`includeEntryFields`, `excludeEntryFields`),
+    .oxor(`includeEntryFields`, `excludeEntryFields`, `entryFieldTransformer`),
 })
 
 const maskedFields = [`accessToken`, `spaceId`]


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description
The `entryFieldTransformer` needs to be added to the plugin-options.js file in order for it to work properly as this was not done before.

This PR takes care of that. It also includes a little note in the README.md file about the new `entryFieldTransformer` option.

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
