### PR TITLE
chore: ensure that entryFieldTransformer and other plugin options can work together

### DIFF
--- a/packages/gatsby-source-contentful/src/__tests__/plugin-options.js
+++ b/packages/gatsby-source-contentful/src/__tests__/plugin-options.js
@@ -178,6 +178,26 @@ describe(`Options validation`, () => {
     expect(reporter.panic).not.toBeCalled()
   })
 
+  it(`Passes when both richText.entryFieldTransformer and richText.includeEntryFields options are passed`, () => {
+    validateOptions(
+      {
+        reporter,
+      },
+      {
+        spaceId: `spaceId`,
+        accessToken: `accessToken`,
+        localeFilter: locale => locale.code === `de`,
+        downloadLocal: false,
+        richText: {
+          includeEntryFields: [`title`],
+          entryFieldTransformer: () => {},
+        },
+      }
+    )
+
+    expect(reporter.panic).not.toBeCalled()
+  })
+
   it(`Fails with missing required options`, () => {
     validateOptions(
       {

--- a/packages/gatsby-source-contentful/src/plugin-options.js
+++ b/packages/gatsby-source-contentful/src/plugin-options.js
@@ -38,7 +38,7 @@ const optionsSchema = Joi.object().keys({
       excludeEntryFields: Joi.array().items(Joi.string()),
       entryFieldTransformer: Joi.func(),
     })
-    .oxor(`includeEntryFields`, `excludeEntryFields`, `entryFieldTransformer`),
+    .oxor(`includeEntryFields`, `excludeEntryFields`),
 })
 
 const maskedFields = [`accessToken`, `spaceId`]


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

This PR helps to ensure that the `entryFieldTransformer` can be used in conjunction with either of  the `includeEntryFields` or `excludeEntryFields` plugin option.

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
