### PR TITLE
 fix: use the getEntries API rather than the Sync API

### DIFF
--- a/packages/gatsby-source-contentful/package.json
+++ b/packages/gatsby-source-contentful/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@clue/gatsby-source-contentful",
   "description": "Gatsby source plugin for building websites using the Contentful CMS as a data source",
-  "version": "2.1.9",
+  "version": "2.1.10",
   "author": "Marcus Ericsson <mericsson@gmail.com> (mericsson.com)",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"

--- a/packages/gatsby-source-contentful/package.json
+++ b/packages/gatsby-source-contentful/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@clue/gatsby-source-contentful",
   "description": "Gatsby source plugin for building websites using the Contentful CMS as a data source",
-  "version": "2.1.10",
+  "version": "2.1.13",
   "author": "Marcus Ericsson <mericsson@gmail.com> (mericsson.com)",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
@@ -15,6 +15,7 @@
     "bluebird": "^3.5.0",
     "chalk": "^2.3.2",
     "contentful": "^6.1.0",
+    "contentful-resolve-response": "^1.1.4",
     "deep-map": "^1.5.0",
     "fs-extra": "^4.0.2",
     "gatsby-plugin-sharp": "^2.2.2",

--- a/packages/gatsby-source-contentful/src/plugin-options.js
+++ b/packages/gatsby-source-contentful/src/plugin-options.js
@@ -34,6 +34,7 @@ const optionsSchema = Joi.object().keys({
   forceFullSync: Joi.boolean(),
   // default plugins passed by gatsby
   plugins: Joi.array(),
+  nodeFilter: Joi.func(),
   richText: Joi.object()
     .keys({
       includeEntryFields: Joi.array().items(Joi.string()),


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
This gets around a bug in the Sync API in which their built-in pagination violated their own 7MB response size limit. As a result, we couldn't use the Sync API. Instead, we're using getEntries to get all entries and assets, and then resolving their links using contentful-resolve-response.


<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
