### PR TITLE
fix: use the getEntries API rather than the Sync API

### DIFF
--- a/packages/gatsby-source-contentful/README.md
+++ b/packages/gatsby-source-contentful/README.md
@@ -168,6 +168,14 @@ If you have entries that reference each other via their rich-text fields, Gatsby
 
 This allows for the transformation of rich-text fields in any way. It allows you to pass in a rich-text field into a function and then modify/add/delete inner field values.
 
+**`entriesPageLimit`** [number][optional] [default: `50`]
+
+The number of entries that should be fetched at a time when using the `getEntries` API. This helps prevent `Response size too big` 400 errors.
+
+**`assetsPageLimit`** [number][optional] [default: `100`]
+
+The number of assets that should be fetched at a time when using the `getAssets` API. This helps prevent `Response size too big` 400 errors.
+
 ## Notes on Contentful Content Models
 
 There are currently some things to keep in mind when building your content models at Contentful.

--- a/packages/gatsby-source-contentful/package.json
+++ b/packages/gatsby-source-contentful/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@clue/gatsby-source-contentful",
   "description": "Gatsby source plugin for building websites using the Contentful CMS as a data source",
-  "version": "2.1.13",
+  "version": "2.2.0",
   "author": "Marcus Ericsson <mericsson@gmail.com> (mericsson.com)",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"

--- a/packages/gatsby-source-contentful/package.json
+++ b/packages/gatsby-source-contentful/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@clue/gatsby-source-contentful",
   "description": "Gatsby source plugin for building websites using the Contentful CMS as a data source",
-  "version": "2.1.10",
+  "version": "2.1.13",
   "author": "Marcus Ericsson <mericsson@gmail.com> (mericsson.com)",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
@@ -15,6 +15,7 @@
     "bluebird": "^3.5.0",
     "chalk": "^2.3.2",
     "contentful": "^6.1.0",
+    "contentful-resolve-response": "^1.1.4",
     "deep-map": "^1.5.0",
     "fs-extra": "^4.0.2",
     "gatsby-plugin-sharp": "^2.2.2",

--- a/packages/gatsby-source-contentful/src/fetch.js
+++ b/packages/gatsby-source-contentful/src/fetch.js
@@ -72,7 +72,7 @@ ${formatPluginOptionsForCLI(pluginConfig.getOriginalPluginOptions(), errors)}`)
   // Temporary replacement for `client.sync`. See details below, where this
   // function is called.
   async function getAllEntriesAndAssets() {
-    const entriesPageSize = 50
+    const entriesPageLimit = pluginConfig.get(`entriesPageLimit`) || 50
 
     let entriesRemaining = true
     let skipEntries = 0
@@ -80,39 +80,39 @@ ${formatPluginOptionsForCLI(pluginConfig.getOriginalPluginOptions(), errors)}`)
     while (entriesRemaining) {
       console.log(
         `FETCHING ENTRIES ${skipEntries + 1} TO ${skipEntries +
-          entriesPageSize}`
+          entriesPageLimit}`
       )
       const fetchedEntries = await client.getEntries({
         include: 0,
         skip: skipEntries,
-        limit: entriesPageSize,
+        limit: entriesPageLimit,
         locale: `*`,
       })
       if (fetchedEntries.items.length) {
         entries = [...entries, ...fetchedEntries.items]
-        skipEntries += entriesPageSize
+        skipEntries += entriesPageLimit
       } else {
         entriesRemaining = false
       }
     }
 
-    const assetsPageSize = 100
+    const assetsPageLimit = pluginConfig.get(`assetsPageLimit`) || 100
 
     let assetsRemaining = true
     let skipAssets = 0
     let assets = []
     while (assetsRemaining) {
       console.log(
-        `FETCHING ASSETS ${skipAssets + 1} TO ${skipAssets + assetsPageSize}`
+        `FETCHING ASSETS ${skipAssets + 1} TO ${skipAssets + assetsPageLimit}`
       )
       const fetchedAssets = await client.getAssets({
         skip: skipAssets,
-        limit: assetsPageSize,
+        limit: assetsPageLimit,
         locale: `*`,
       })
       if (fetchedAssets.items.length) {
         assets = [...assets, ...fetchedAssets.items]
-        skipAssets += assetsPageSize
+        skipAssets += assetsPageLimit
       } else {
         assetsRemaining = false
       }

--- a/packages/gatsby-source-contentful/src/plugin-options.js
+++ b/packages/gatsby-source-contentful/src/plugin-options.js
@@ -42,6 +42,8 @@ const optionsSchema = Joi.object().keys({
       entryFieldTransformer: Joi.func(),
     })
     .oxor(`includeEntryFields`, `excludeEntryFields`),
+  entriesPageLimit: Joi.number(),
+  assetsPageLimit: Joi.number(),
 })
 
 const maskedFields = [`accessToken`, `spaceId`]


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
This gets around a bug in the Sync API in which their built-in pagination violated their own 7MB response size limit. As a result, we couldn't use the Sync API. Instead, we're using getEntries to get all entries and assets, and then resolving their links using contentful-resolve-response.


<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
